### PR TITLE
exclude security_txt from no-entrypoint builds

### DIFF
--- a/programs/vrf-flip/src/lib.rs
+++ b/programs/vrf-flip/src/lib.rs
@@ -251,6 +251,7 @@ pub enum VrfFlipError {
     FlipRequestedTooSoon,
 }
 
+#[cfg(not(feature = "no-entrypoint"))]
 security_txt! {
     name: "Switchboard VRF Flip",
     project_url: "https://switchboard.xyz/",


### PR DESCRIPTION
The usage of `solana-security-txt` previously recommended in the official usage guide has an issue:

When multiple projects within a build, including dependencies, define a security-txt, the build fails.

To avoid this issue, library authors - including projects that *might* be used as a library by others in the future - should exclude the `security_txt` macro during `no-entrypoint` builds.

Feel free to read up on the details in [the issue on the security-txt repository](https://github.com/neodyme-labs/solana-security-txt/issues/11).

The [official usage guide](https://github.com/neodyme-labs/solana-security-txt#usage) has also been updated. This PR includes the recommended changes.
